### PR TITLE
new address

### DIFF
--- a/template.xml
+++ b/template.xml
@@ -57,7 +57,7 @@
 		<organization>Wikimedia Deutschland e.V.</organization>
 		<address>
 			<postal>
-				<street>Obentrautstr. 72</street>
+				<street>Tempelhofer Ufer 23-24</street>
 				<city>Berlin</city>
 				<code>10963</code>
 				<country>Germany</country>


### PR DESCRIPTION
Wikimedia Deutschland's office moved to a new place in Berlin
